### PR TITLE
Update .npmignore to prevent fixtures from ending in the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,17 @@
+# Rules from: .gitignore
+node_modules
+.serverless
+.serverless_plugins
+mappings.json
+essent-serverless-plugin-canary-deployments*.tgz
+.vscode
+*.iml
+.idea
+
+# Custom rules
+.circleci/
+.github/
 example/
+fixtures/
+.editorconfig
+*.test.js

--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,7 @@ node_modules
 .serverless
 .serverless_plugins
 mappings.json
-essent-serverless-plugin-canary-deployments*.tgz
+serverless-plugin-canary-deployments*.tgz
 .vscode
 *.iml
 .idea


### PR DESCRIPTION
The fixtures folder is by far the most of the size of the package, but there's no need for it to be packaged at all. This MR takes care of that.

<img width="1327" alt="image" src="https://github.com/user-attachments/assets/53752efe-f21e-4f54-baa1-ab782ab6fb9e">
