### PR TITLE
deps!: Fix serialize-javascript RCE and bump minimum Node to 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8071,16 +8071,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8512,13 +8502,13 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serverless": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "standard": "*"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=20.0"
       },
       "peerDependencies": {
         "serverless": ">= 1.26.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
   "peerDependencies": {
     "serverless": ">= 1.26.0"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
+  },
   "keywords": [
     "aws",
     "lambda",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flagsmith/serverless-plugin-canary-deployments",
   "engines": {
-    "node": ">=18.0"
+    "node": ">=20.0"
   },
   "version": "1.1.0",
   "description": "A Serverless plugin to implement canary deployment of Lambda functions",


### PR DESCRIPTION
Resolves [GHSA-5c6j-r48x-rmvq](https://github.com/Flagsmith/serverless-plugin-canary-deployments/security/dependabot/139) (RCE via `RegExp.flags` / `Date.toISOString`) by overriding the transitive `serialize-javascript` to `^7.0.3`. `serialize-javascript@7` requires Node >=20, so this PR also bumps `engines.node` to match — a breaking change for consumers still on Node 18 (which is already EOL).

**BREAKING CHANGE:** minimum supported Node version is now 20.